### PR TITLE
Correction to source rather than conda

### DIFF
--- a/Lab 1 - Introduction to Spark and HPC.md
+++ b/Lab 1 - Introduction to Spark and HPC.md
@@ -74,7 +74,7 @@ When you are asked whether to proceed, say `y`. Python 3.6.3 allows pasting mult
 
 #### Activate the environment
 
-`conda activate myspark`
+`source activate myspark`
 
 You **must** see `(myspark) [abc1de@sharc-nodeXXX ~]$`, i.e. **(myspark)** in front, before proceeding. Otherwise, you did not get the proper environment. Check the above steps. 
 


### PR DESCRIPTION
ShARC's conda modules do not support the use of conda activate.