### PR TITLE
Correction to PySpark SQL API link

### DIFF
--- a/Lab 1 - Introduction to Spark and HPC.md
+++ b/Lab 1 - Introduction to Spark and HPC.md
@@ -495,7 +495,7 @@ You are encouraged to try out in the pyspark shell first to figure out the right
 
 ### More log mining questions
 
-You are encouraged to explore these more challenging questions by consulting the [`pyspark.sql` APIs](https://spark.apache.org/docs/3.2.1/api/python/pyspark.sql.html) to learn more. We will not provide solutions but Session 2 will make answering these questions easier.
+You are encouraged to explore these more challenging questions by consulting the [`pyspark.sql` APIs](https://spark.apache.org/docs/3.2.1/api/python/reference/pyspark.sql.html) to learn more. We will not provide solutions but Session 2 will make answering these questions easier.
 
 - How many **unique** hosts on a particular day (e.g., 15th August)?
 - How many **unique** hosts in total (i.e., in August 1995)?


### PR DESCRIPTION
Updating the `pyspark.sql` API hyperlink which currently leads to a 404 page.